### PR TITLE
Harden dependency automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,25 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 ---
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-    schedule:
-      interval: monthly
+- package-ecosystem: github-actions
+  directory: "/"
+  groups:
+    github-actions:
+      patterns:
+      - "*"
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 45
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 45
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 45

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       # execute the branch-deploy action
-      - uses: github/branch-deploy@v11
+      - uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11
         id: branch-deploy
         with:
           trigger: ".deploy"
@@ -61,7 +61,7 @@ jobs:
     steps:
       # checkout the project's repository based on the sha provided by the branch-deploy step
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # pin@v5
         with:
           ref: ${{ needs.trigger.outputs.sha }}
 
@@ -82,7 +82,7 @@ jobs:
       # configure the GitHub Pages action
       - name: setup pages
         id: pages
-        uses: actions/configure-pages@v5.0.0
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # pin@v5.0.0
 
       # build the site with hugo
       - name: build with hugo
@@ -96,7 +96,7 @@ jobs:
 
       # upload the built site as an artifact for the deploy step
       - name: upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # pin@v4
         with:
           path: ./public
 
@@ -110,7 +110,7 @@ jobs:
       # deploy the site to GitHub Pages
       - name: deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # pin@v4
 
   # update the deployment result - manually complete the deployment that was created by the branch-deploy action
   result:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # pin@v5
 
       # read the hugo version from the .hugo-version file in this repository
       - name: set hugo version

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       # https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/merge-commit-strategy.md
       - name: deployment check
-        uses: github/branch-deploy@v11
+        uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11
         id: deployment-check
         with:
           merge_deploy_mode: "true"
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # pin@v5
 
       - name: set hugo version
         id: hugo-version
@@ -64,7 +64,7 @@ jobs:
 
       - name: setup pages
         id: pages
-        uses: actions/configure-pages@v5.0.0
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # pin@v5.0.0
 
       - name: build with hugo
         run: hugo --gc --logLevel info --baseURL ${{ steps.pages.outputs.base_url }}
@@ -73,7 +73,7 @@ jobs:
         run: echo ${GITHUB_SHA} > ./public/version.txt
 
       - name: upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # pin@v4
         with:
           path: ./public
 
@@ -88,4 +88,4 @@ jobs:
     steps:
       - name: deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # pin@v4

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       # Comment on new PR requests with deployment instructions
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # pin@v5
       - name: comment
         uses: GrantBirki/comment@608e41b19bc973020ec0e189ebfdae935d7fe0cc # pin@v2.1.1
         continue-on-error: true

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: github/branch-deploy@v11
+        uses: github/branch-deploy@fded0351b6b79f854b335c11b3d93063461dd288 # pin@v11
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow


### PR DESCRIPTION
This pins mutable GitHub Actions references where needed and adds 45-day Dependabot cooldowns for configured dependency ecosystems.