### PR TITLE
Enable Copy Markdown site-wide

### DIFF
--- a/_vendor/github.com/GrantBirki/dario/assets/css/default.css
+++ b/_vendor/github.com/GrantBirki/dario/assets/css/default.css
@@ -477,6 +477,58 @@ center {
   line-height: 1.4;
 }
 
+.page-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75em;
+  margin-block-start: 2em;
+}
+
+.page-meta .author-date {
+  margin-block: 0;
+}
+
+.page-meta-home {
+  margin-block-start: 1em;
+}
+
+.copy-markdown-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+  min-block-size: 2.25em;
+  padding: 0.35em 0.65em;
+  color: var(--muted-text-color);
+  background-color: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5em;
+  font: inherit;
+  font-size: 0.8em;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.copy-markdown-button:hover {
+  color: var(--text-color);
+  background-color: var(--footnote-bg-color);
+}
+
+.copy-markdown-button:focus-visible {
+  outline: 2px solid var(--focus-color);
+  outline-offset: 2px;
+}
+
+.copy-markdown-button:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.copy-markdown-icon {
+  flex: none;
+  fill: currentColor;
+}
+
 .mobile-toc-link,
 .toc-container h2 {
   font-size: 1.2em;

--- a/_vendor/github.com/GrantBirki/dario/assets/js/copy-markdown.js
+++ b/_vendor/github.com/GrantBirki/dario/assets/js/copy-markdown.js
@@ -1,0 +1,63 @@
+"use strict";
+
+function copyMarkdownFallback(markdown) {
+  const textarea = document.createElement("textarea");
+  textarea.value = markdown;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand("copy");
+  textarea.remove();
+
+  if (!copied) {
+    throw new Error("Copy command failed");
+  }
+}
+
+async function copyMarkdown(markdown) {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(markdown);
+    return;
+  }
+
+  copyMarkdownFallback(markdown);
+}
+
+function initializeCopyMarkdownButton(button) {
+  const label = button.querySelector(".copy-markdown-label");
+  const source = document.getElementById(button.dataset.copyMarkdownTarget);
+
+  if (!label || !source) {
+    return;
+  }
+
+  const defaultLabel = label.textContent;
+  button.addEventListener("click", async () => {
+    button.disabled = true;
+
+    try {
+      await copyMarkdown(JSON.parse(source.textContent));
+      label.textContent = "Copied!";
+    } catch (_error) {
+      label.textContent = "Copy failed";
+    }
+
+    button.disabled = false;
+    button.focus();
+    window.setTimeout(() => {
+      label.textContent = defaultLabel;
+    }, 2000);
+  });
+}
+
+function initializeCopyMarkdownButtons() {
+  document.querySelectorAll(".copy-markdown-button").forEach(initializeCopyMarkdownButton);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeCopyMarkdownButtons);
+} else {
+  initializeCopyMarkdownButtons();
+}

--- a/_vendor/github.com/GrantBirki/dario/layouts/_default/single.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/_default/single.html
@@ -1,9 +1,17 @@
 {{- define "main" }}
+    {{- $copyMarkdownEnabled := partial "copy-markdown/enabled.html" . }}
     <h1>{{ .Title | .RenderString }}</h1>
     <h4>{{ .Params.description }}</h4>
 
-    {{- if isset .Params "date" }}
-    <p class="author-date">{{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}</p>
+    {{- if or (isset .Params "date") $copyMarkdownEnabled }}
+    <div class="page-meta">
+        {{- if isset .Params "date" }}
+        <p class="author-date">{{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}</p>
+        {{- end }}
+        {{- if $copyMarkdownEnabled }}
+{{ partial "copy-markdown/button.html" . }}
+        {{- end }}
+    </div>
     {{- end }}
 
 {{ .Content }}

--- a/_vendor/github.com/GrantBirki/dario/layouts/index.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/index.html
@@ -1,9 +1,16 @@
 {{- define "main" }}
+    {{- $home := . }}
+    {{- $copyMarkdownEnabled := partial "copy-markdown/enabled.html" . }}
     {{- with .Site.GetPage "_index.md" }}
         {{- if .Params.homePageIsPost }}
     <h1>{{ .Title | .RenderString }}</h1>
     <h4>{{ .Params.description }}</h4>
-    <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
+    <div class="page-meta">
+        <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
+        {{- if $copyMarkdownEnabled }}
+{{ partial "copy-markdown/button.html" $home }}
+        {{- end }}
+    </div>
 
 {{ .Content }}
         {{- else }}
@@ -13,6 +20,11 @@
     <h1 class="smaller">{{ $subtitle }}</h1>
 {{ . }}
     </section>
+            {{- end }}
+            {{- if $copyMarkdownEnabled }}
+    <div class="page-meta page-meta-home">
+{{ partial "copy-markdown/button.html" $home }}
+    </div>
             {{- end }}
         {{- end }}
     {{- end }}

--- a/_vendor/github.com/GrantBirki/dario/layouts/partials/copy-markdown/button.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/partials/copy-markdown/button.html
@@ -1,0 +1,9 @@
+{{- $markdown := partial "copy-markdown/content.html" . -}}
+<button type="button" class="copy-markdown-button" data-copy-markdown-target="copy-markdown-source">
+    <svg class="copy-markdown-icon" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M7.024 3.75c0-.966.784-1.75 1.75-1.75H20.25c.966 0 1.75.784 1.75 1.75v11.498a1.75 1.75 0 0 1-1.75 1.75H8.774a1.75 1.75 0 0 1-1.75-1.75Zm1.75-.25a.25.25 0 0 0-.25.25v11.498c0 .139.112.25.25.25H20.25a.25.25 0 0 0 .25-.25V3.75a.25.25 0 0 0-.25-.25Z" />
+        <path d="M1.995 10.749a1.75 1.75 0 0 1 1.75-1.751H5.25a.75.75 0 1 1 0 1.5H3.745a.25.25 0 0 0-.25.25L3.5 20.25c0 .138.111.25.25.25h9.5a.25.25 0 0 0 .25-.25v-1.51a.75.75 0 1 1 1.5 0v1.51A1.75 1.75 0 0 1 13.25 22h-9.5A1.75 1.75 0 0 1 2 20.25l-.005-9.501Z" />
+    </svg>
+    <span class="copy-markdown-label" aria-live="polite">Copy Markdown</span>
+</button>
+<script type="application/json" id="copy-markdown-source">{{ $markdown | jsonify | safeJS }}</script>

--- a/_vendor/github.com/GrantBirki/dario/layouts/partials/copy-markdown/content.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/partials/copy-markdown/content.html
@@ -1,0 +1,21 @@
+{{- $source := . -}}
+{{- if .IsHome -}}
+    {{- with .Site.GetPage "_index.md" }}{{- $source = . -}}{{- end -}}
+{{- end -}}
+{{- $title := $source.Title | $source.RenderString | plainify | htmlUnescape -}}
+{{- $markdown := printf "# %s\n" $title -}}
+{{- with strings.TrimSpace $source.RawContent -}}
+    {{- $markdown = printf "%s\n%s\n" $markdown . -}}
+{{- end -}}
+{{- if .IsHome -}}
+    {{- range sort (where .Site.Sections "Section" "in" .Site.MainSections) "Weight" -}}
+        {{- $sectionTitle := .Title | .RenderString | plainify | htmlUnescape -}}
+        {{- $markdown = printf "%s\n## %s\n" $markdown $sectionTitle -}}
+        {{- range where .Site.RegularPages "Section" .Section -}}
+            {{- $pageTitle := .Title | .RenderString | plainify | htmlUnescape -}}
+            {{- $markdown = printf "%s\n- [%s](%s)" $markdown $pageTitle .Permalink -}}
+        {{- end -}}
+        {{- $markdown = printf "%s\n" $markdown -}}
+    {{- end -}}
+{{- end -}}
+{{- return printf "%s\n" (strings.TrimSpace $markdown) -}}

--- a/_vendor/github.com/GrantBirki/dario/layouts/partials/copy-markdown/enabled.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/partials/copy-markdown/enabled.html
@@ -1,0 +1,14 @@
+{{- $enabled := false -}}
+{{- with .Site.Params.copyMarkdown -}}
+    {{- if .enabled -}}
+        {{- $enabled = true -}}
+        {{- if $.IsHome -}}
+            {{- if isset . "home" }}{{- $enabled = .home -}}{{- end -}}
+        {{- else if $.IsPage -}}
+            {{- if isset . "posts" }}{{- $enabled = .posts -}}{{- end -}}
+        {{- else -}}
+            {{- $enabled = false -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- return $enabled -}}

--- a/_vendor/github.com/GrantBirki/dario/layouts/partials/head.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/partials/head.html
@@ -46,6 +46,11 @@
     <script src="{{ $darkmodeJS.RelPermalink }}" integrity="{{ $darkmodeJS.Data.Integrity }}" defer></script>
     {{- end }}
 
+    {{- if partial "copy-markdown/enabled.html" . }}
+    {{- $copyMarkdownJS := resources.Get "js/copy-markdown.js" | minify | fingerprint }}
+    <script src="{{ $copyMarkdownJS.RelPermalink }}" integrity="{{ $copyMarkdownJS.Data.Integrity }}" defer></script>
+    {{- end }}
+
     {{- with .Content }}
         {{- if or (in . "id=\"fnref") (in . "class=\"footnote-ref\"") }}
             {{- $footnotesJS := resources.Get "js/footnotes.js" | minify | fingerprint }}

--- a/_vendor/github.com/GrantBirki/dario/theme.toml
+++ b/_vendor/github.com/GrantBirki/dario/theme.toml
@@ -17,6 +17,7 @@ tags = [
 
 features = [
   "blog",
+  "copy-markdown",
   "opengraph",
   "theme-toggle"
 ]

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,1 +1,1 @@
-# github.com/GrantBirki/dario v0.0.0-20260719060028-139febbe9791
+# github.com/GrantBirki/dario v0.0.0-20260720001913-2697df1181a8

--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,9 @@ title = "log"
   author = "Grant Birkinbine"
   description = "A minimal web log by Grant Birkinbine."
 
+  [params.copyMarkdown]
+    enabled = true
+
   [params.homeInfoParams]
     Title = "Grant Birkinbine"
     Content = "This is a minimal web log inspired by Dario Amodei's personal [website](https://darioamodei.com/). It is designed to be as minimal, performant, and as elegant as possible for reading. It is built with [Hugo](https://gohugo.io/) which is a static site generator written in Go. The theme is open source and available on [GitHub](https://github.com/GrantBirki/dario)."

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module log.birki.io
 
 go 1.24.3
 
-require github.com/GrantBirki/dario v0.0.0-20260719060028-139febbe9791 // indirect
+require github.com/GrantBirki/dario v0.0.0-20260720001913-2697df1181a8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/GrantBirki/dario v0.0.0-20260719060028-139febbe9791 h1:xAWi6qcMtEUPKLeyjfvhQLqJcoaFEaKrdof6583w45o=
 github.com/GrantBirki/dario v0.0.0-20260719060028-139febbe9791/go.mod h1:s8A8b1QpPglY2oKoL2flTEIX9EIVI56Pkwp35GksM/I=
+github.com/GrantBirki/dario v0.0.0-20260720001913-2697df1181a8 h1:YlA2YI2cPVdXYk+PYtZFXvm8tc0RAUxMh2oSrmfgZ0g=
+github.com/GrantBirki/dario v0.0.0-20260720001913-2697df1181a8/go.mod h1:s8A8b1QpPglY2oKoL2flTEIX9EIVI56Pkwp35GksM/I=


### PR DESCRIPTION
Adds a Copy Markdown button to the Log landing page and every post, making the source content easy to paste into LLM prompts. The site now enables Dario's new control globally and refreshes the committed theme snapshot to the exact merged upstream revision `2697df1181a8c6f3081272b965a36de42e20e1ec`.

This keeps the site Node-free and preserves the existing vendored, offline Hugo build path.
