### PR TITLE
Refresh Dario page controls

### DIFF
--- a/_vendor/github.com/GrantBirki/dario/assets/css/default.css
+++ b/_vendor/github.com/GrantBirki/dario/assets/css/default.css
@@ -58,6 +58,8 @@ header h1 a {
   --code-block-bg: #0d1117;
   --code-block-border: #30363d;
   --muted-text-color: #b3b3b3;
+  --control-border-color: #444;
+  --control-bg-color: transparent;
 }
 
 .dark-mode-off:root {
@@ -81,6 +83,8 @@ header h1 a {
   --code-block-bg: #f7f7f7;
   --code-block-border: #d0d7de;
   --muted-text-color: #666666;
+  --control-border-color: #85827b;
+  --control-bg-color: rgba(255, 255, 255, 0.35);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -105,6 +109,8 @@ header h1 a {
     --code-block-bg: #0d1117;
     --code-block-border: #30363d;
     --muted-text-color: #b3b3b3;
+    --control-border-color: #444;
+    --control-bg-color: transparent;
   }
 }
 
@@ -130,6 +136,8 @@ header h1 a {
     --code-block-bg: #f7f7f7;
     --code-block-border: #d0d7de;
     --muted-text-color: #666666;
+    --control-border-color: #85827b;
+    --control-bg-color: rgba(255, 255, 255, 0.35);
   }
 }
 
@@ -320,8 +328,13 @@ header h1 a {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  inline-size: 250px;
+  inline-size: 100%;
   padding-block-start: 2px;
+}
+
+header h1 {
+  flex: 0 1 250px;
+  min-inline-size: 0;
 }
 
 header h1 a {
@@ -345,6 +358,23 @@ p a:hover {
   opacity: 1;
   pointer-events: auto;
   transition: opacity 0.2s ease;
+}
+
+.header-posts-link {
+  color: var(--muted-text-color);
+  font-size: 0.75em;
+  line-height: 1;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.header-posts-link:hover {
+  color: var(--text-color);
+}
+
+.header-posts-link:focus-visible {
+  outline: 2px solid var(--focus-color);
+  outline-offset: 3px;
 }
 
 /* Toggle Switch Styles */
@@ -479,8 +509,8 @@ center {
 
 .page-meta {
   display: flex;
-  align-items: center;
-  flex-wrap: wrap;
+  flex-direction: column;
+  align-items: flex-start;
   gap: 0.75em;
   margin-block-start: 2em;
 }
@@ -500,8 +530,8 @@ center {
   min-block-size: 2.25em;
   padding: 0.35em 0.65em;
   color: var(--muted-text-color);
-  background-color: transparent;
-  border: 1px solid var(--border-color);
+  background-color: var(--control-bg-color);
+  border: 1px solid var(--control-border-color);
   border-radius: 0.5em;
   font: inherit;
   font-size: 0.8em;

--- a/_vendor/github.com/GrantBirki/dario/layouts/_default/single.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/_default/single.html
@@ -5,11 +5,11 @@
 
     {{- if or (isset .Params "date") $copyMarkdownEnabled }}
     <div class="page-meta">
-        {{- if isset .Params "date" }}
-        <p class="author-date">{{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}</p>
-        {{- end }}
         {{- if $copyMarkdownEnabled }}
 {{ partial "copy-markdown/button.html" . }}
+        {{- end }}
+        {{- if isset .Params "date" }}
+        <p class="author-date">{{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}</p>
         {{- end }}
     </div>
     {{- end }}

--- a/_vendor/github.com/GrantBirki/dario/layouts/index.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/index.html
@@ -6,10 +6,10 @@
     <h1>{{ .Title | .RenderString }}</h1>
     <h4>{{ .Params.description }}</h4>
     <div class="page-meta">
-        <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
         {{- if $copyMarkdownEnabled }}
 {{ partial "copy-markdown/button.html" $home }}
         {{- end }}
+        <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
     </div>
 
 {{ .Content }}

--- a/_vendor/github.com/GrantBirki/dario/layouts/partials/header.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/partials/header.html
@@ -4,6 +4,9 @@
             <a href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
         </h1>
         <div class="header-controls">
+            {{- if .Site.Params.showPostsLink }}
+            <a class="header-posts-link" href="{{ "posts/" | relLangURL }}">posts</a>
+            {{- end }}
             <div class="toggle-switch">
                 <input type="checkbox" id="darkModeToggle" class="toggle-input" aria-label="Toggle dark mode">
                 <label for="darkModeToggle" class="toggle-label">

--- a/_vendor/github.com/GrantBirki/dario/theme.toml
+++ b/_vendor/github.com/GrantBirki/dario/theme.toml
@@ -19,6 +19,7 @@ features = [
   "blog",
   "copy-markdown",
   "opengraph",
+  "posts-link",
   "theme-toggle"
 ]
 

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,1 +1,1 @@
-# github.com/GrantBirki/dario v0.0.0-20260720001913-2697df1181a8
+# github.com/GrantBirki/dario v0.0.0-20260720024556-1a23cac70f8d

--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,7 @@ title = "log"
 
   author = "Grant Birkinbine"
   description = "A minimal web log by Grant Birkinbine."
+  showPostsLink = true
 
   [params.copyMarkdown]
     enabled = true

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module log.birki.io
 
 go 1.24.3
 
-require github.com/GrantBirki/dario v0.0.0-20260720001913-2697df1181a8 // indirect
+require github.com/GrantBirki/dario v0.0.0-20260720024556-1a23cac70f8d // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/GrantBirki/dario v0.0.0-20260719060028-139febbe9791 h1:xAWi6qcMtEUPKL
 github.com/GrantBirki/dario v0.0.0-20260719060028-139febbe9791/go.mod h1:s8A8b1QpPglY2oKoL2flTEIX9EIVI56Pkwp35GksM/I=
 github.com/GrantBirki/dario v0.0.0-20260720001913-2697df1181a8 h1:YlA2YI2cPVdXYk+PYtZFXvm8tc0RAUxMh2oSrmfgZ0g=
 github.com/GrantBirki/dario v0.0.0-20260720001913-2697df1181a8/go.mod h1:s8A8b1QpPglY2oKoL2flTEIX9EIVI56Pkwp35GksM/I=
+github.com/GrantBirki/dario v0.0.0-20260720024556-1a23cac70f8d h1:bLno1by94g/LWqjs1gbEaKqfFrUjlt3Eh0h0YthrOao=
+github.com/GrantBirki/dario v0.0.0-20260720024556-1a23cac70f8d/go.mod h1:s8A8b1QpPglY2oKoL2flTEIX9EIVI56Pkwp35GksM/I=


### PR DESCRIPTION
Refreshes the vendored Dario theme to merged commit `1a23cac70f8d37e3650c484943d393de89b67b4a`, moving Copy Markdown above page dates and improving its light-mode visibility.

Enables the optional lowercase `posts` header link globally while retaining the existing global Copy Markdown setting. The theme remains pinned through its immutable Go pseudo-version and committed vendor snapshot.
