### PR TITLE
Refresh Dario spacing

### DIFF
--- a/_vendor/github.com/GrantBirki/dario/assets/css/default.css
+++ b/_vendor/github.com/GrantBirki/dario/assets/css/default.css
@@ -354,7 +354,7 @@ p a:hover {
 .header-controls {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 10px;
   opacity: 1;
   pointer-events: auto;
   transition: opacity 0.2s ease;
@@ -362,7 +362,7 @@ p a:hover {
 
 .header-posts-link {
   color: var(--muted-text-color);
-  font-size: 0.75em;
+  font-size: 0.85em;
   line-height: 1;
   text-decoration: none;
   white-space: nowrap;
@@ -375,6 +375,13 @@ p a:hover {
 .header-posts-link:focus-visible {
   outline: 2px solid var(--focus-color);
   outline-offset: 3px;
+}
+
+.header-control-separator {
+  inline-size: 1px;
+  block-size: 1.1em;
+  background-color: var(--muted-text-color);
+  opacity: 0.65;
 }
 
 /* Toggle Switch Styles */
@@ -511,8 +518,8 @@ center {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.75em;
-  margin-block-start: 2em;
+  gap: 1em;
+  margin-block: 1.5em;
 }
 
 .page-meta .author-date {

--- a/_vendor/github.com/GrantBirki/dario/layouts/_default/single.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/_default/single.html
@@ -5,11 +5,11 @@
 
     {{- if or (isset .Params "date") $copyMarkdownEnabled }}
     <div class="page-meta">
-        {{- if $copyMarkdownEnabled }}
-{{ partial "copy-markdown/button.html" . }}
-        {{- end }}
         {{- if isset .Params "date" }}
         <p class="author-date">{{ printf `<time datetime="%s">%s</time>` (.Date.Format "2006-01-02T15:04:05Z07:00") (.Date.Format "January 2, 2006") | safeHTML }}</p>
+        {{- end }}
+        {{- if $copyMarkdownEnabled }}
+{{ partial "copy-markdown/button.html" . }}
         {{- end }}
     </div>
     {{- end }}

--- a/_vendor/github.com/GrantBirki/dario/layouts/index.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/index.html
@@ -6,10 +6,10 @@
     <h1>{{ .Title | .RenderString }}</h1>
     <h4>{{ .Params.description }}</h4>
     <div class="page-meta">
+        <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
         {{- if $copyMarkdownEnabled }}
 {{ partial "copy-markdown/button.html" $home }}
         {{- end }}
-        <p class="author-date"><time datetime="{{ .Date }}">{{ .Date.Format "January 2, 2006" }}</time> - {{ .Params.author }}</p>
     </div>
 
 {{ .Content }}

--- a/_vendor/github.com/GrantBirki/dario/layouts/partials/header.html
+++ b/_vendor/github.com/GrantBirki/dario/layouts/partials/header.html
@@ -6,6 +6,7 @@
         <div class="header-controls">
             {{- if .Site.Params.showPostsLink }}
             <a class="header-posts-link" href="{{ "posts/" | relLangURL }}">posts</a>
+            <span class="header-control-separator" aria-hidden="true"></span>
             {{- end }}
             <div class="toggle-switch">
                 <input type="checkbox" id="darkModeToggle" class="toggle-input" aria-label="Toggle dark mode">

--- a/_vendor/modules.txt
+++ b/_vendor/modules.txt
@@ -1,1 +1,1 @@
-# github.com/GrantBirki/dario v0.0.0-20260720024556-1a23cac70f8d
+# github.com/GrantBirki/dario v0.0.0-20260720033433-4ce78438931e

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module log.birki.io
 
 go 1.24.3
 
-require github.com/GrantBirki/dario v0.0.0-20260720024556-1a23cac70f8d // indirect
+require github.com/GrantBirki/dario v0.0.0-20260720033433-4ce78438931e // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/GrantBirki/dario v0.0.0-20260720001913-2697df1181a8 h1:YlA2YI2cPVdXYk
 github.com/GrantBirki/dario v0.0.0-20260720001913-2697df1181a8/go.mod h1:s8A8b1QpPglY2oKoL2flTEIX9EIVI56Pkwp35GksM/I=
 github.com/GrantBirki/dario v0.0.0-20260720024556-1a23cac70f8d h1:bLno1by94g/LWqjs1gbEaKqfFrUjlt3Eh0h0YthrOao=
 github.com/GrantBirki/dario v0.0.0-20260720024556-1a23cac70f8d/go.mod h1:s8A8b1QpPglY2oKoL2flTEIX9EIVI56Pkwp35GksM/I=
+github.com/GrantBirki/dario v0.0.0-20260720033433-4ce78438931e h1:q5jcVCuykfWfaVXD+t/bW5t1mAnrW0WRvsZtjOFFm0E=
+github.com/GrantBirki/dario v0.0.0-20260720033433-4ce78438931e/go.mod h1:s8A8b1QpPglY2oKoL2flTEIX9EIVI56Pkwp35GksM/I=


### PR DESCRIPTION
Refreshes the vendored Dario theme to merged commit `4ce78438931e40c461ba4b43ca2ef09018e53d9b`, adding separation between the posts link and theme toggle and increasing the link size.

Moves Copy Markdown below page dates with more even spacing across the top metadata block. The immutable Go pseudo-version and committed vendor snapshot remain the dependency authority.