### PR TITLE
Add Fence v0.8.7 in audit mode

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -22,7 +22,7 @@ jobs:
       contains(github.event.comment.body, '.help') ||
       contains(github.event.comment.body, '.wcid') ||
       contains(github.event.comment.body, '.unlock')) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
       deployments: write
@@ -41,6 +41,10 @@ jobs:
       actor_handle: ${{ steps.branch-deploy.outputs.actor_handle }}
 
     steps:
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       # execute the branch-deploy action
       - uses: github/branch-deploy@ddf8ca48e9cdb2d2c7c71dee428308b19af9313f # pin@v11.1.4
         id: branch-deploy
@@ -56,11 +60,15 @@ jobs:
   build:
     needs: trigger
     if: ${{ needs.trigger.outputs.continue == 'true' }} # only run if the trigger job set continue to true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
 
     steps:
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       - name: checkout trusted tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
         with:
@@ -141,12 +149,16 @@ jobs:
   deploy:
     needs: [ trigger, build ]
     if: ${{ needs.trigger.outputs.continue == 'true' && needs.trigger.outputs.noop != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pages: write
       id-token: write
 
     steps:
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       # deploy the site to GitHub Pages
       - name: deploy
         id: deployment
@@ -155,7 +167,7 @@ jobs:
   # update the deployment result - manually complete the deployment that was created by the branch-deploy action
   result:
     needs: [ trigger, build, deploy ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     # run even on failures but only if the trigger job set continue to true
     if: ${{ always() && needs.trigger.outputs.continue == 'true' && needs.trigger.outputs.noop != 'true' }}
     permissions:
@@ -165,6 +177,10 @@ jobs:
       pull-requests: write
 
     steps:
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       # if a previous step failed, set a variable to use as the deployment status
       - name: set deployment status
         id: deploy-status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,13 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,11 +28,15 @@ permissions:
 
 jobs:
   deployment-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs: # set outputs for use in downstream jobs
       continue: ${{ steps.deployment-check.outputs.continue }}
 
     steps:
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       # https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/merge-commit-strategy.md
       - name: deployment check
         uses: github/branch-deploy@ddf8ca48e9cdb2d2c7c71dee428308b19af9313f # pin@v11.1.4
@@ -44,9 +48,13 @@ jobs:
   build:
     if: ${{ needs.deployment-check.outputs.continue == 'true' }}
     needs: deployment-check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
 
@@ -92,9 +100,13 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       - name: deploy
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # pin@v5.0.0

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -12,9 +12,13 @@ permissions:
 jobs:
   comment:
     if: github.event_name == 'pull_request' && github.event.action == 'opened'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       # Comment on new PR requests with deployment instructions
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
       - name: comment

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -11,9 +11,13 @@ permissions:
 
 jobs:
   unlock-on-merge:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
+      - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
+
       - name: unlock on merge
         uses: github/branch-deploy@ddf8ca48e9cdb2d2c7c71dee428308b19af9313f # pin@v11.1.4
         id: unlock-on-merge


### PR DESCRIPTION
Adds Fence v0.8.7 as the first step in every Ubuntu job and pins those jobs to Ubuntu 24.04. This initial PR intentionally keeps Fence in audit mode so default-branch-only branch-deploy and Pages paths can be exercised before a follow-up enforcement PR.