### PR TITLE
Enforce Fence v0.8.7

### DIFF
--- a/.github/fence-enforcement-placeholder.md
+++ b/.github/fence-enforcement-placeholder.md
@@ -1,0 +1,3 @@
+# Fence enforcement rollout
+
+This temporary marker keeps the audit deployment tree distinct from `main` while the observed destinations are reviewed. It will be removed when the enforcement configuration is ready.

--- a/.github/fence-enforcement-placeholder.md
+++ b/.github/fence-enforcement-placeholder.md
@@ -1,3 +1,0 @@
-# Fence enforcement rollout
-
-This temporary marker keeps the audit deployment tree distinct from `main` while the observed destinations are reviewed. It will be removed when the enforcement configuration is ready.

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -91,7 +91,11 @@ jobs:
       - name: install vendored hugo cli
         env:
           HUGO_VERSION: ${{ steps.hugo-version.outputs.HUGO_VERSION }}
-        run: sudo dpkg -i tooling/bin/vendor/hugo_extended_${HUGO_VERSION}_linux-amd64.deb
+        run: |
+          install_root="$RUNNER_TEMP/hugo-${HUGO_VERSION}"
+          mkdir -p "$install_root"
+          dpkg-deb --extract "tooling/bin/vendor/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" "$install_root"
+          echo "$install_root/usr/local/bin" >> "$GITHUB_PATH"
 
       - name: verify installed hugo cli
         env:

--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -42,8 +42,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       # execute the branch-deploy action
       - uses: github/branch-deploy@ddf8ca48e9cdb2d2c7c71dee428308b19af9313f # pin@v11.1.4
@@ -66,8 +64,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: checkout trusted tooling
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
@@ -156,8 +152,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       # deploy the site to GitHub Pages
       - name: deploy
@@ -178,8 +172,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       # if a previous step failed, set a variable to use as the deployment status
       - name: set deployment status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,11 @@ jobs:
       - name: install vendored hugo cli
         env:
           HUGO_VERSION: ${{ steps.hugo-version.outputs.HUGO_VERSION }}
-        run: sudo dpkg -i bin/vendor/hugo_extended_${HUGO_VERSION}_linux-amd64.deb
+        run: |
+          install_root="$RUNNER_TEMP/hugo-${HUGO_VERSION}"
+          mkdir -p "$install_root"
+          dpkg-deb --extract "bin/vendor/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" "$install_root"
+          echo "$install_root/usr/local/bin" >> "$GITHUB_PATH"
 
       # build the site with hugo
       - name: build with hugo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       # https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/merge-commit-strategy.md
       - name: deployment check
@@ -52,8 +50,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2
@@ -104,8 +100,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: deploy
         id: deployment

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,11 @@ jobs:
       - name: install vendored hugo cli
         env:
           HUGO_VERSION: ${{ steps.hugo-version.outputs.HUGO_VERSION }}
-        run: sudo dpkg -i bin/vendor/hugo_extended_${HUGO_VERSION}_linux-amd64.deb
+        run: |
+          install_root="$RUNNER_TEMP/hugo-${HUGO_VERSION}"
+          mkdir -p "$install_root"
+          dpkg-deb --extract "bin/vendor/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" "$install_root"
+          echo "$install_root/usr/local/bin" >> "$GITHUB_PATH"
 
       - name: setup pages
         id: pages

--- a/.github/workflows/new-pr.yml
+++ b/.github/workflows/new-pr.yml
@@ -16,8 +16,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       # Comment on new PR requests with deployment instructions
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6.0.2

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -15,8 +15,6 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
-        with:
-          mode: audit
 
       - name: unlock on merge
         uses: github/branch-deploy@ddf8ca48e9cdb2d2c7c71dee428308b19af9313f # pin@v11.1.4


### PR DESCRIPTION
Moves all ten Ubuntu 24.04 jobs from Fence audit mode to enforcement after authenticated summary review. No custom allowlist is needed; Fence’s default GitHub compatibility profile remains unchanged. Vendored Hugo packages are checksum-verified and extracted into the runner temp directory so builds remain compatible with Fence’s sudo hardening.
